### PR TITLE
Fix openssl linkage problems for few linux systems

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -99,7 +99,7 @@ TARGET_USES_VULKAN := true
 
 ## Kernel
 BOARD_KERNEL_IMAGE_NAME := Image
-TARGET_KERNEL_ADDITIONAL_FLAGS := HOSTCFLAGS="-fuse-ld=lld -Wno-unused-command-line-argument"
+TARGET_KERNEL_ADDITIONAL_FLAGS := HOSTCFLAGS="-fuse-ld=lld -Wno-unused-command-line-argument -I/usr/include" HOSTLDFLAGS="-L/usr/lib/x86_64-linux-gnu"
 TARGET_KERNEL_NO_GCC := true
 
 ## Keymaster


### PR DESCRIPTION
Fixes the kernel compilation problem when compiling a ROM and also on bare kernel compilation. (atleast on cachyOS (arch))