### PR TITLE
universal9611-common: Add schedtune boosts from 9820

### DIFF
--- a/configs/init/init.exynos9611.rc
+++ b/configs/init/init.exynos9611.rc
@@ -448,6 +448,10 @@ on boot
 
     setprop vendor.powerhal.init 1
 
+    # PAS Setting
+    write /sys/devices/system/cpu/cpu0/cpufreq/schedutil/freqvar_boost 5
+    write /sys/devices/system/cpu/cpu4/cpufreq/schedutil/freqvar_boost 20
+
     # Cstate node
     chown radio system /sys/module/cpuidle/parameters/off
     chmod 0664 /sys/module/cpuidle/parameters/off

--- a/configs/init/init.exynos9611.rc
+++ b/configs/init/init.exynos9611.rc
@@ -77,6 +77,32 @@ on init
 
     write /dev/stune/schedtune.boost 0
 
+    chown system system /dev/stune/top-app/schedtune.boost
+    chown system system /dev/stune/top-app/schedtune.prefer_idle
+    chown system system /dev/stune/top-app/schedtune.prefer_perf
+    chown system system /dev/stune/foreground/schedtune.boost
+    chown system system /dev/stune/foreground/schedtune.prefer_idle
+    chown system system /dev/stune/foreground/schedtune.prefer_perf
+    chown system system /dev/stune/background/schedtune.boost
+    chown system system /dev/stune/background/schedtune.prefer_idle
+    chown system system /dev/stune/background/schedtune.prefer_perf
+
+    write /dev/stune/top-app/schedtune.boost 5
+    write /dev/stune/top-app/schedtune.prefer_idle 1
+    write /dev/stune/top-app/schedtune.prefer_perf 0
+    write /dev/stune/top-app/schedtune.util_est_en 1
+    write /dev/stune/top-app/schedtune.ontime_en 1
+
+    write /dev/stune/foreground/schedtune.boost 0
+    write /dev/stune/foreground/schedtune.prefer_idle 0
+    write /dev/stune/foreground/schedtune.prefer_perf 0
+    write /dev/stune/foreground/schedtune.util_est_en 1
+    write /dev/stune/foreground/schedtune.ontime_en 1
+
+    write /dev/stune/background/schedtune.boost 0
+    write /dev/stune/background/schedtune.prefer_idle 0
+    write /dev/stune/background/schedtune.prefer_perf 0
+
     chown system system /dev/cpuset/tasks
     chown system system /dev/cpuset/cgroup.procs
     chmod 0664 /dev/cpuset/tasks


### PR DESCRIPTION
We also having these nodes on 9611 too so why not use it
